### PR TITLE
Fix Insert() and UpdateOne() argument data types.

### DIFF
--- a/mongo.go
+++ b/mongo.go
@@ -41,7 +41,7 @@ func (*Mongo) NewClient(connURI string) interface{} {
 
 const filter_is string = "filter is "
 
-func (c *Client) Insert(database string, collection string, doc map[string]string) error {
+func (c *Client) Insert(database string, collection string, doc any) error {
 	db := c.client.Database(database)
 	col := db.Collection(collection)
 	_, err := col.InsertOne(context.TODO(), doc)
@@ -95,7 +95,7 @@ func (c *Client) FindOne(database string, collection string, filter map[string]s
 	return nil
 }
 
-func (c *Client) UpdateOne(database string, collection string, filter interface{}, data map[string]string) error {
+func (c *Client) UpdateOne(database string, collection string, filter interface{}, data any) error {
 	// var result bson.M
 	db := c.client.Database(database)
 	col := db.Collection(collection)


### PR DESCRIPTION
### Requirement
As a user I want to be able to store nested objects in the database using `Insert()` and `UpdateOne()` methods.

### Solution
Replace `map[string]string` with `any` type for the `data` parameter.