### PR TITLE
Add NewClientWithOptions method for passing custom ClientOptions to the mongo connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,36 @@ export default ()=> {
 
 ```
 
+
+### Passing custom `clientOptions` to the mongo client
+
+If we need to pass extra options to the driver connection we can pass a [ClientOptions](https://pkg.go.dev/go.mongodb.org/mongo-driver@v1.15.0/mongo/options#ClientOptions) object.
+
+In this example, we are specifying the use of the [stable api](https://www.mongodb.com/docs/drivers/go/v1.15/fundamentals/stable-api/), with strict compatibility. We are also setting the application name via the `app_name` property as `"k6-test-app"`, so the connection can be identified in the logs server-side.
+
+```js
+import xk6_mongo from 'k6/x/mongo';
+
+const clientOptions = {
+    "app_name": "k6-test-app",
+    "server_api_options": {
+        "server_api_version": "1",
+        "strict": true
+    }
+};
+
+const client = xk6_mongo.newClientWithOptions('mongodb://localhost:27017', clientOptions);
+export default ()=> {
+
+    let doc = {
+        correlationId: `test--mongodb`,
+        title: 'Perf test experiment',
+        url: 'example.com',
+        locale: 'en',
+        time: `${new Date(Date.now()).toISOString()}`
+    };
+
+    client.insert("testdb", "testcollection", doc);
+}
+```
+

--- a/examples/test-client-options.js
+++ b/examples/test-client-options.js
@@ -1,0 +1,27 @@
+import xk6_mongo from 'k6/x/mongo';
+
+const clientOptions = {
+  "app_name": "k6-test-app", 
+  
+  "server_api_options": { 
+      "server_api_version": "1",
+      "strict": true 
+  }
+};
+
+const client = xk6_mongo.newClientWithOptions('mongodb://localhost:27017', clientOptions);
+
+export default ()=> {
+
+  let doc = {
+      correlationId: `test--mongodb`,
+      title: 'Perf test experiment',
+      url: 'example.com',
+      locale: 'en',
+      time: `${new Date(Date.now()).toISOString()}`
+    };
+
+    let error = client.insert("testdb", "testcollection", doc);
+    if (error) 
+        console.log(error.message);
+}

--- a/mongo.go
+++ b/mongo.go
@@ -33,10 +33,15 @@ type UpsertOneModel struct {
 // NewClient represents the Client constructor (i.e. `new mongo.Client()`) and
 // returns a new Mongo client object.
 // connURI -> mongodb://username:password@address:port/db?connect=direct
-func (*Mongo) NewClient(connURI string) *Client {
+func (m *Mongo) NewClient(connURI string) *Client {
+	return m.NewClientWithOptions(connURI, options.Client())
+}
+
+func (*Mongo) NewClientWithOptions(connURI string, clientOptions *options.ClientOptions) *Client {
 	log.Print("start creating new client")
 
-	clientOptions := options.Client().ApplyURI(connURI)
+	clientOptions.ApplyURI(connURI)
+
 	client, err := mongo.Connect(context.Background(), clientOptions)
 	if err != nil {
 		log.Printf("Error while establishing a connection to MongoDB: %v", err)


### PR DESCRIPTION
Implementation of an additional method which passes a ClientOptions object to the mongo client.

This allows further customization of the client options.

This snipped shows how the new method is called.

```javascript
const mongoUri = `mongodb://mongo-user:mongo-password@127.0.0.1:27017/admin?connect=direct`
const clientOptions = {
    "app_name": "MyApp", 
    //...
    "server_api_options": { 
        "server_api_version": "1",
        "strict": true 
    }
    //...
};
const client = xk6_mongo.newClientWithOptions(mongoUri, clientOptions)
```
