### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/GhMartingit/xk6-mongo/security/code-scanning/4](https://github.com/GhMartingit/xk6-mongo/security/code-scanning/4)

To resolve the issue, an explicit `permissions` block should be added to restrict the permissions of the `GITHUB_TOKEN` to the minimum required for the job. For jobs that only need to check out code and build/test (`lint`, `test`, `build`), usually `contents: read` is sufficient. You can set `permissions` either at the workflow root (applies to all jobs unless overridden), or individually per job. To minimize changes and avoid future risk, it's best to add the block at the workflow level—right after `name: CI`, and before `on:`—to apply least privilege to all jobs in the workflow. The syntax is:

```yaml
permissions:
  contents: read
```

No imports or library changes are needed, only YAML configuration edits.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
