### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build and publish xk6-mongo
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/GhMartingit/xk6-mongo/security/code-scanning/1](https://github.com/GhMartingit/xk6-mongo/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow, restricting the permissions of the GITHUB_TOKEN to only those necessary to successfully execute the workflow steps. For this workflow, release creation (using `softprops/action-gh-release@v1`) requires `contents: write`, but most other steps only need read-access. A minimal fix is to add a `permissions` block at the root level of the workflow (before the `jobs:` key), setting `contents: write`. If further minimization is required, you can set `default` job permissions to `contents: read` and override them for jobs that require write access—however, here a minimal and practical fix is to set `contents: write` for the entire workflow.

You should add:
```yaml
permissions:
  contents: write
```
immediately after the workflow `name:` (on line 2).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
